### PR TITLE
Put DarkerShadows on tree, move Mug and Nimble down

### DIFF
--- a/traitTrees/thief.yml
+++ b/traitTrees/thief.yml
@@ -12,9 +12,9 @@ Thief:
           - name: ImprovedSteal
             maxLevel: 1
 
-          - name: Mug
+          - name: DarkerShadows
             maxLevel: 1
-            requires: ImprovedSteal
+            requires: 
 
           - name: ImprovedHide
             maxLevel: 1
@@ -25,8 +25,8 @@ Thief:
             maxLevel: 1
 
         - traits:
-          - name: NimbleFingers
-            maxLevel: 5
+          - name: Mug
+            maxLevel: 1
             requires: ImprovedSteal
 
           - name: ''
@@ -41,7 +41,9 @@ Thief:
             maxLevel: 5
           
         - traits: 
-          - name: ''
+          - name: NimbleFingers
+            maxLevel: 5
+            requires: ImprovedSteal
 
           - name: Disguise
             maxLevel: 1

--- a/traitTrees/thief.yml
+++ b/traitTrees/thief.yml
@@ -14,7 +14,6 @@ Thief:
 
           - name: DarkerShadows
             maxLevel: 1
-            requires: 
 
           - name: ImprovedHide
             maxLevel: 1


### PR DESCRIPTION
### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Can you post a screenshot of your changes (if applicable)?
before:
![image](https://user-images.githubusercontent.com/6930354/116762922-fb171480-a9e9-11eb-8589-9eddc23da40b.png)

after:
![image](https://user-images.githubusercontent.com/6930354/116762894-e89cdb00-a9e9-11eb-804d-de1a68f6d109.png)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
DarkerShadows is a global drop rune; should be early on tree. Moved the other two down from our chat