### PR TITLE
Raise crafting level for golden staves

### DIFF
--- a/recipes/metalworking/antanian-tree.yml
+++ b/recipes/metalworking/antanian-tree.yml
@@ -123,8 +123,8 @@
   name: Golden Staff
   category: Antanian Weaponry
   skillGained: 2
-  maxSkillForGains: 8
-  requireSkill: 4
+  maxSkillForGains: 12
+  requireSkill: 8
   xpGained: 15000
   ozIngredients:
     - filter: Gold Ore

--- a/recipes/metalworking/risan-tree.yml
+++ b/recipes/metalworking/risan-tree.yml
@@ -123,8 +123,8 @@
   name: Golden Staff II
   category: Risan Weaponry
   skillGained: 2
-  maxSkillForGains: 17
-  requireSkill: 13
+  maxSkillForGains: 22
+  requireSkill: 18
   xpGained: 15000
   ozIngredients:
     - filter: Old Ore


### PR DESCRIPTION
### All Submissions

* [x] Have you followed the guidelines in our Contributing document?

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Bumping gold staff reqs to 8/18 for progression reasons (covers a gap in crafting weapons for levels 8-10)